### PR TITLE
Forced publication to a new repository

### DIFF
--- a/api/src/main/java/com/sample/java/library/api/SomeApi.java
+++ b/api/src/main/java/com/sample/java/library/api/SomeApi.java
@@ -1,7 +1,7 @@
 package com.sample.java.library.api;
 
 /**
- * Sample API interface
+ * Sample API interface for testing
  */
 public interface SomeApi {
     public void someApiMethod();

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -17,7 +17,8 @@ allprojects {
            key = System.getenv("BINTRAY_API_KEY")
 
            pkg {
-               repo = 'samples'
+               userOrg = 'linkedin'
+               repo = 'maven'
                user = 'szczepiq'
                name = 'sample-java-library'
                licenses = ['Apache-2.0']


### PR DESCRIPTION
- updating javadoc bypasses Shipkit's checking if the binaries have changed
- shipping to a different repository reduces reliance on jCenter